### PR TITLE
feat(BoardTab): implement name truncation for leaderboard entries

### DIFF
--- a/apps/spore/src/components/BoardTab.tsx
+++ b/apps/spore/src/components/BoardTab.tsx
@@ -16,10 +16,10 @@ import LoaderCircle from './LoaderCircle'
 /*
  * utils
  */
-function truncateName(name: string, visibleChars: number = 10): string {
+function truncateName(name: string, visibleChars: number = 25): string {
   if (name.length <= visibleChars) return name
-  const lastPart = name.slice(-5)
-  const firstPart = name.slice(0, visibleChars - 5)
+  const lastPart = name.slice(-visibleChars)
+  const firstPart = name.slice(0, visibleChars - lastPart.length)
   return `${firstPart}...${lastPart}`
 }
 

--- a/apps/spore/src/components/BoardTab.tsx
+++ b/apps/spore/src/components/BoardTab.tsx
@@ -13,6 +13,19 @@ import { useStore } from '@/store'
 import { LeaderBoard, TotalLeaderBoard } from '@/types/referral'
 import LoaderCircle from './LoaderCircle'
 
+/*
+ * utils
+ */
+function truncateName(name: string, visibleChars: number = 10): string {
+  if (name.length <= visibleChars) return name
+  const lastPart = name.slice(-5)
+  const firstPart = name.slice(0, visibleChars - 5)
+  return `${firstPart}...${lastPart}`
+}
+
+/*
+ * components
+ */
 export default function BoardTab({
   tab,
 }: {
@@ -147,7 +160,7 @@ const TeamTabContent = ({
   const rows = lb.map((data) => {
     return (
       <tr className="[&>td]:py-2 [&>td]:px-6" key={data.userId}>
-        <td>{data.userId}</td>
+        <td>{truncateName(data.userId)}</td>
         <td className="text-right">{data.totalPoints}</td>
       </tr>
     )
@@ -185,7 +198,7 @@ const PlayerTabContent = ({
   const rows = lb.map((data) => {
     return (
       <tr className="[&>td]:py-2 [&>td]:px-6" key={data.userId}>
-        <td>{data.userId}</td>
+        <td>{truncateName(data.userId)}</td>
         <td className="text-right">{data.totalPoints}</td>
       </tr>
     )

--- a/apps/spore/src/components/BoardTab.tsx
+++ b/apps/spore/src/components/BoardTab.tsx
@@ -9,6 +9,7 @@ import {
   useGetTeamLeaderBoardByUserId,
   useGetTotalLeaderBoard,
 } from '@/hooks/useReferral'
+import { isMobile } from '@/lib/utils'
 import { useStore } from '@/store'
 import { LeaderBoard, TotalLeaderBoard } from '@/types/referral'
 import LoaderCircle from './LoaderCircle'
@@ -16,10 +17,17 @@ import LoaderCircle from './LoaderCircle'
 /*
  * utils
  */
-function truncateName(name: string, visibleChars: number = 25): string {
+function truncateName(
+  name: string,
+  visibleCharsMobile: number = 15,
+  visibleCharsPC: number = 25
+): string {
+  const visibleChars = isMobile() ? visibleCharsMobile : visibleCharsPC
+
   if (name.length <= visibleChars) return name
-  const lastPart = name.slice(-visibleChars)
-  const firstPart = name.slice(0, visibleChars - lastPart.length)
+  const lastPartLength = visibleChars - 5
+  const lastPart = name.slice(-lastPartLength)
+  const firstPart = name.slice(0, visibleChars - lastPartLength)
   return `${firstPart}...${lastPart}`
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a user ID truncation feature in the leaderboard for improved readability.
	- Enhanced presentation by displaying a cleaner format of user IDs, preserving the last five characters for context.

- **Bug Fixes**
	- Resolved overflow issues in the leaderboard tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->